### PR TITLE
Fixing Exception - implode(): Argument #1 ($pieces) must be of type array, string given

### DIFF
--- a/classes/notocopy_form.php
+++ b/classes/notocopy_form.php
@@ -36,7 +36,8 @@ class notocopy_form extends \moodleform {
         global $DB;
         $cm = $this->_customdata['cm'];
         $id = $this->_customdata['id'];
-        $users = $this->_customdata['users'];
+        $userscustomdata = $this->_customdata['users'];
+        $users = isset($userscustomdata) && is_array($userscustomdata) ? $userscustomdata : [];
         $mform = $this->_form;
         $mform->addElement('static', 'submitnotoforgrading_tree_teacherlabel', '', get_string('submitnotoforgrading_tree_teacherlabel', 'assignfeedback_noto'));
         $mform->addElement('text', 'assignsubmission_noto_directory', get_string('assignsubmission_noto_directory_destination', 'assignfeedback_noto').

--- a/classes/notocopy_form.php
+++ b/classes/notocopy_form.php
@@ -36,6 +36,7 @@ class notocopy_form extends \moodleform {
         global $DB;
         $cm = $this->_customdata['cm'];
         $id = $this->_customdata['id'];
+        $users = $this->_customdata['users'];
         $mform = $this->_form;
         $mform->addElement('static', 'submitnotoforgrading_tree_teacherlabel', '', get_string('submitnotoforgrading_tree_teacherlabel', 'assignfeedback_noto'));
         $mform->addElement('text', 'assignsubmission_noto_directory', get_string('assignsubmission_noto_directory_destination', 'assignfeedback_noto').
@@ -57,7 +58,7 @@ class notocopy_form extends \moodleform {
         $mform->setType('plugin', PARAM_PLUGIN);
         $mform->addElement('hidden', 'pluginsubtype', 'assignfeedback');
         $mform->setType('pluginsubtype', PARAM_PLUGIN);
-        $mform->addElement('hidden', 'selectedusers', implode(',', $this->_customdata['users']));
+        $mform->addElement('hidden', 'selectedusers', implode(',', $users));
         $mform->setType('selectedusers', PARAM_SEQUENCE);
         $mform->setType('id', PARAM_INT);
         \assign_feedback_noto::mform_add_catalog_tree($mform, $cm->course);

--- a/classes/notocopyfeedback_form.php
+++ b/classes/notocopyfeedback_form.php
@@ -36,26 +36,8 @@ class notocopyfeedback_form extends \moodleform {
         global $DB;
         $cm = $this->_customdata['cm'];
         $id = $this->_customdata['id'];
-
-//        if (isset($this->_customdata['submission'])) {
-//            $submission = $this->_customdata['submission'];
-//        }
+        $users = $this->_customdata['users'];
         $mform = $this->_form;
-        /*
-        if (!empty($submission)) {
-            $mform->addElement('static', 'submissiondate', get_string('submissiondate', 'assignsubmission_noto'), date('D M j G:i:s T Y', $submission->timemodified));
-            $teacher_copy = $DB->get_record('assignsubmission_noto_tcopy', ['studentid'=>$submission->userid, 'assignmentid'=>$submission->assignment]);
-            if ($teacher_copy) {
-                # is this the most recent submission?
-                if ($teacher_copy->timecreated > $submission->timemodified) {
-                    #$mform->addElement('static', 'pagehelp', get_string('info', 'assignsubmission_noto'), get_string('viewsubmissions_recentcopy', 'assignsubmission_noto'));
-                    #return;
-                } else {
-                    $mform->addElement('static', 'pagehelp', get_string('attention', 'assignsubmission_noto'), get_string('viewsubmissions_diffcopy', 'assignsubmission_noto'));
-                }
-            }
-        }
-        */
         $mform->addElement('static', 'submitnotoforgrading_tree_teacherlabel', '', get_string('submitnotofeedback_tree_teacherlabel', 'assignfeedback_noto'));
         $mform->addElement('text', 'assignsubmission_noto_directory', get_string('assignsubmission_noto_directory_destination', 'assignsubmission_noto').
             '<div id="submit-jupyter"></div>', array('id'=>'assignsubmission_noto_directory', 'size'=>80));
@@ -64,32 +46,24 @@ class notocopyfeedback_form extends \moodleform {
         $mform->freeze('assignsubmission_noto_directory');
         $mform->addElement('hidden', 'assignsubmission_noto_directory_h', '', array('id'=>'assignsubmission_noto_directory_h'));  # _h is for "hidden" if you're wondering
         $mform->setType('assignsubmission_noto_directory_h', PARAM_TEXT);
-//        if (!empty($submission)) {
-//            $mform->addElement('hidden', 'id', $submission->id);
-//        } else {
-            $mform->addElement('hidden', 'id', $id);
-            $mform->addElement('hidden', 'operation', 'plugingradingbatchoperation_noto_uploadnoto');
-            $mform->setType('operation', PARAM_ALPHAEXT);
-            $mform->addElement('hidden', 'action', 'viewpluginpage');
-            $mform->setType('action', PARAM_ALPHA);
-            $mform->addElement('hidden', 'pluginaction', 'uploadnoto');
-            $mform->setType('pluginaction', PARAM_ALPHA);
-            $mform->addElement('hidden', 'plugin', 'noto');
-            $mform->setType('plugin', PARAM_PLUGIN);
-            $mform->addElement('hidden', 'pluginsubtype', 'assignfeedback');
-            $mform->setType('pluginsubtype', PARAM_PLUGIN);
-            $mform->addElement('hidden', 'selectedusers', implode(',', $this->_customdata['users']));
-            $mform->setType('selectedusers', PARAM_SEQUENCE);
-//        }
+        $mform->addElement('hidden', 'id', $id);
+        $mform->addElement('hidden', 'operation', 'plugingradingbatchoperation_noto_uploadnoto');
+        $mform->setType('operation', PARAM_ALPHAEXT);
+        $mform->addElement('hidden', 'action', 'viewpluginpage');
+        $mform->setType('action', PARAM_ALPHA);
+        $mform->addElement('hidden', 'pluginaction', 'uploadnoto');
+        $mform->setType('pluginaction', PARAM_ALPHA);
+        $mform->addElement('hidden', 'plugin', 'noto');
+        $mform->setType('plugin', PARAM_PLUGIN);
+        $mform->addElement('hidden', 'pluginsubtype', 'assignfeedback');
+        $mform->setType('pluginsubtype', PARAM_PLUGIN);
+        $mform->addElement('hidden', 'selectedusers', implode(',', $users));
+        $mform->setType('selectedusers', PARAM_SEQUENCE);
         $mform->setType('id', PARAM_INT);
         \assign_feedback_noto::mform_add_catalog_tree($mform, $cm->course);
         $buttonarray=array();
         $buttonarray[] =& $mform->createElement('submit', 'reload', get_string('reloadtree', 'assignsubmission_noto'), ['id'=>'assignsubmission_noto_reloadtree_submit']);
- //       if (empty($this->_customdata['users'])) {
-            $buttonarray[] =& $mform->createElement('submit', 'submitbutton', get_string('copyfeedback', 'assignfeedback_noto'));
- //       } else {
- //           $buttonarray[] =& $mform->createElement('submit', 'submitbutton', get_string('copyfeedback', 'assignfeedback_noto'));
- //       }
+        $buttonarray[] =& $mform->createElement('submit', 'submitbutton', get_string('copyfeedback', 'assignfeedback_noto'));
         $buttonarray[] =& $mform->createElement('submit', 'cancel', get_string('cancel'));
         $mform->addGroup($buttonarray, 'buttonar', '', array(' '), false);
     }

--- a/classes/notocopyfeedback_form.php
+++ b/classes/notocopyfeedback_form.php
@@ -36,7 +36,8 @@ class notocopyfeedback_form extends \moodleform {
         global $DB;
         $cm = $this->_customdata['cm'];
         $id = $this->_customdata['id'];
-        $users = $this->_customdata['users'];
+        $userscustomdata = $this->_customdata['users'];
+        $users = isset($userscustomdata) && is_array($userscustomdata) ? $userscustomdata : [];
         $mform = $this->_form;
         $mform->addElement('static', 'submitnotoforgrading_tree_teacherlabel', '', get_string('submitnotofeedback_tree_teacherlabel', 'assignfeedback_noto'));
         $mform->addElement('text', 'assignsubmission_noto_directory', get_string('assignsubmission_noto_directory_destination', 'assignsubmission_noto').

--- a/locallib.php
+++ b/locallib.php
@@ -24,6 +24,7 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
+use \mod_assign\output\assign_header;
 
 define('FILEAREA', 'noto_zips');
 define('ASSIGNFEEDBACK_NOTO_FILEAREA', 'feedback_noto');

--- a/uploadfeedback.php
+++ b/uploadfeedback.php
@@ -27,7 +27,6 @@ use core\notification;
 require_once(dirname(__FILE__) . '/../../../../config.php');
 require_once(dirname(__FILE__) . '/locallib.php');
 require_once($CFG->libdir . '/formslib.php');
-define('ASSIGNFEEDBACK_NOTO_FILEAREA', 'feedback_noto');
 
 $cmid = required_param('id', PARAM_INT);
 

--- a/uploadfeedback.php
+++ b/uploadfeedback.php
@@ -44,8 +44,8 @@ $PAGE->set_url('/mod/assign/feedback/noto/uploadfeedback.php', array('id' => $cm
 $context = context_module::instance($cm->id);
 $PAGE->set_context($context);
 $PAGE->set_cm($cm);
-$PAGE->set_title(get_string('viewuploadfeedback_pagetitle', 'assignfeedback_noto', fullname($student)));
-$PAGE->set_heading(get_string('viewuploadfeedback_pagetitle', 'assignfeedback_noto', fullname($student)));
+$PAGE->set_title(get_string('viewuploadfeedback_pagetitle', 'assignfeedback_noto'));
+$PAGE->set_heading(get_string('viewuploadfeedback_pagetitle', 'assignfeedback_noto'));
 $PAGE->set_pagelayout('standard');
 require_login($cm->course);
 $config = get_config('assignfeedbacknoto');


### PR DESCRIPTION
The form seems to be used in 2 actions, but without accommodating for when no users selected (ie no array of users formed).

Reference Error:

Debug-Info: 
Error code: generalexceptionmessage×Diese Systemnachricht ablehnen
Stack trace:  * line 60 of /mod/assign/feedback/noto/classes/notocopy_form.php: TypeError thrown

line 60 of /mod/assign/feedback/noto/classes/notocopy_form.php: call to implode()
line 214 of /lib/formslib.php: call to assignfeedback_noto\notocopy_form->definition()
line 58 of /mod/assign/feedback/noto/uploadfeedback.php: call to moodleform->__construct()
×Diese Systemnachricht ablehnen
Ausgabepuffer:  <br /> <b>Warning</b>: Constant ASSIGNFEEDBACK_NOTO_FILEAREA already defined in <b>/var/www/html/moodle/mod/assign/feedback/noto/uploadfeedback.php</b> on line <b>30</b><br /> <br /> <b>Warning</b>: Undefined variable $student in <b>/var/www/html/moodle/mod/assign/feedback/noto/uploadfeedback.php</b> on line <b>48</b><br /> <br /> <b>Warning</b>: Undefined variable $student in <b>/var/www/html/moodle/mod/assign/feedback/noto/uploadfeedback.php</b> on line <b>49</b><br /> <br /> <b>Warning</b>: Undefined array key "users" in <b>/var/www/html/moodle/mod/assign/feedback/noto/classes/notocopy_form.php</b> on line <b>60</b><br />

 